### PR TITLE
JAXBContext.newInstance( String contextPath ) javadoc is missing the @param and @return values

### DIFF
--- a/jaxb-api/src/main/java/javax/xml/bind/JAXBContext.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/JAXBContext.java
@@ -349,6 +349,14 @@ public abstract class JAXBContext {
      * {@link #newInstance(String,ClassLoader)} method with
      * the context class loader of the current thread.
      *
+     * @param contextPath
+     *      List of java package names that contain schema
+     *      derived class and/or java to schema (JAXB-annotated)
+     *      mapped classes.
+     *      Packages in {@code contextPath} that are in named modules must be
+     *      {@linkplain java.lang.Module#isOpen open} to at least the {@code java.xml.bind} module.
+     *
+     * @return a new instance of a {@code JAXBContext}
      * @throws JAXBException if an error was encountered while creating the
      *                       {@code JAXBContext} such as
      * <ol>


### PR DESCRIPTION
The change is for  JDK-8185668: JAXBContext.newInstance( String contextPath ) javadoc is missing the @param and @return values
@bravehorsie @lukasj @m0mus @Xiaojwu @HOHOWU 