### PR TITLE
Classloading improvements + log fixes

### DIFF
--- a/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
@@ -429,7 +429,9 @@ class ContextFinder {
     private static String classNameFromPackageProperties(URL packagePropertiesUrl,
                                                          String ... factoryIds) throws JAXBException {
 
-        logger.log(Level.FINE, "Trying to locate {0}", packagePropertiesUrl.toString());
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "Trying to locate {0}", packagePropertiesUrl.toString());
+        }
         Properties props = loadJAXBProperties(packagePropertiesUrl);
         for(String factoryId : factoryIds) {
             if (props.containsKey(factoryId)) {
@@ -492,7 +494,9 @@ class ContextFinder {
             is.close();
             return props;
         } catch (IOException ioe) {
-            logger.log(Level.FINE, "Unable to load " + url.toString(), ioe);
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Unable to load " + url.toString(), ioe);
+            }
             throw new JAXBException(ioe.toString(), ioe);
         }
     }

--- a/jaxb-api/src/main/java/javax/xml/bind/ServiceLoaderUtil.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ServiceLoaderUtil.java
@@ -67,8 +67,11 @@ class ServiceLoaderUtil {
             ServiceLoader<P> serviceLoader = ServiceLoader.load(spiClass);
 
             for (P impl : serviceLoader) {
-                logger.fine("ServiceProvider loading Facility used; returning object [" +
-                        impl.getClass().getName() + "]");
+                if (logger.isLoggable(Level.FINE))
+                {
+                    logger.fine(
+                          "ServiceProvider loading Facility used; returning object [" + impl.getClass().getName() + "]");
+                }
 
                 return impl;
             }
@@ -88,8 +91,10 @@ class ServiceLoaderUtil {
             Iterator iter = ((Iterable) m.invoke(null, serviceClass)).iterator();
             if (iter.hasNext()) {
                 Object next = iter.next();
-                logger.fine("Found implementation using OSGi facility; returning object [" +
-                        next.getClass().getName() + "].");
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.fine("Found implementation using OSGi facility; returning object [" +
+                            next.getClass().getName() + "].");
+                }
                 return next;
             } else {
                 return null;
@@ -99,7 +104,9 @@ class ServiceLoaderUtil {
                 ClassNotFoundException |
                 NoSuchMethodException ignored) {
 
-            logger.log(Level.FINE, "Unable to find from OSGi: [" + factoryId + "]", ignored);
+            if (logger.isLoggable(Level.FINE)) { 
+                logger.log(Level.FINE, "Unable to find from OSGi: [" + factoryId + "]", ignored);
+            }
             return null;
         }
     }

--- a/jaxb-api/src/main/java/javax/xml/bind/ServiceLoaderUtil.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ServiceLoaderUtil.java
@@ -60,11 +60,12 @@ class ServiceLoaderUtil {
     private static final String OSGI_SERVICE_LOADER_METHOD_NAME = "lookupProviderClasses";
 
     static <P, T extends Exception> P firstByServiceLoader(Class<P> spiClass,
+                                                           ClassLoader loader,
                                                            Logger logger,
                                                            ExceptionHandler<T> handler) throws T {
         // service discovery
         try {
-            ServiceLoader<P> serviceLoader = ServiceLoader.load(spiClass);
+            ServiceLoader<P> serviceLoader = loader != null ? ServiceLoader.load(spiClass, loader) : ServiceLoader.load(spiClass);
 
             for (P impl : serviceLoader) {
                 if (logger.isLoggable(Level.FINE))


### PR DESCRIPTION
This allows for proper/better integration of JAXB API into WildFly. The changes remove the assumption that the thread context classloader is set in a way that allows the ServiceLoader to create a JAXBContext from it, basically allowing for discovery / creation through the API defining classloader too.
Besides that, few minor optimizations on logs.