### PR TITLE
Fixes api jar for SE8 and OSGi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/jaxb-api/target/

--- a/jaxb-api-test/src/test/java/javax/xml/bind/test/JAXBContextTest.java
+++ b/jaxb-api-test/src/test/java/javax/xml/bind/test/JAXBContextTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2015-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2017 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -82,7 +82,7 @@ public class JAXBContextTest {
     private static final String FACTORY_ID = "javax.xml.bind.JAXBContextFactory";
     private static final String PACKAGE_LEGACY = "jaxb.factory.legacy."; // TODO: ???
     private static final String PACKAGE_SPI = "jaxb.factory.spi."; // TODO: ???
-    private static final Object DEFAULT = "com.sun.xml.bind.v2.runtime.JAXBContextImpl";
+    private static final Object DEFAULT = "com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl";
 
 
     static {

--- a/jaxb-api-test/src/test/java/javax/xml/bind/test/JAXBContextTest.java
+++ b/jaxb-api-test/src/test/java/javax/xml/bind/test/JAXBContextTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2015-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/jaxb-api/pom.xml
+++ b/jaxb-api/pom.xml
@@ -171,6 +171,7 @@
                             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         </archive>
                         <instructions>
+                            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version>=1.8))"</Require-Capability>
                             <Bundle-Version>${project.version}</Bundle-Version>  <!-- 2.2.99.bnull -->
                             <Extension-Name>${extension.name}</Extension-Name>
                             <Implementation-Version>${spec.version}.${impl.version}</Implementation-Version>

--- a/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2003-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003-2017 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -70,10 +70,19 @@ import java.util.logging.Logger;
 class ContextFinder {
 
     /**
-     * Previously used to point into JavaSE provider now defaults to RI context factory class.
-     * This will be used as the last resort if none of other resolution mechanism is successful.
+     * When JAXB is in J2SE, rt.jar has to have a JAXB implementation.
+     * However, rt.jar cannot have META-INF/services/javax.xml.bind.JAXBContext
+     * because if it has, it will take precedence over any file that applications have
+     * in their jar files.
+     *
+     * <p>
+     * When the user bundles his own JAXB implementation, we'd like to use it, and we
+     * want the platform default to be used only when there's no other JAXB provider.
+     *
+     * <p>
+     * For this reason, we have to hard-code the class name into the API.
      */
-    private static final String PLATFORM_DEFAULT_FACTORY_CLASS = "com.sun.xml.bind.v2.ContextFactory";
+    private static final String PLATFORM_DEFAULT_FACTORY_CLASS = "com.sun.xml.internal.bind.v2.ContextFactory";
 
     // previous value of JAXBContext.JAXB_CONTEXT_FACTORY, using also this to ensure backwards compatibility
     private static final String JAXB_CONTEXT_FACTORY_DEPRECATED = "javax.xml.bind.context.factory";

--- a/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
+++ b/jaxb-api/src/main/java/javax/xml/bind/ContextFinder.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2003-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
* fixed osgi runtime requirement to allow newer JDKs
* reverted commit 10c9fb5 as it broke ability to find default implementation on JavaSE 8